### PR TITLE
Remove the BEGIN and END opcodes

### DIFF
--- a/src/main/java/pokerga/Interpreter.java
+++ b/src/main/java/pokerga/Interpreter.java
@@ -93,14 +93,8 @@ public final class Interpreter {
       // This main loop drives the overall processing. Other loops will
       // likely be called based on the opcodes consumed in this loop.
       while (buf.hasRemaining()) {
-
-        // This will seek until it finds the BEG marker. At that point,
-        // it will BEG token and continue with other codes.
-        seekTo(OpCode.BEG);
-
-        // This will execute operations until it reaches the END marker.
-        // It will also call process with END before finishing out.
-        execUntil(OpCode.END);
+        // Execute instructions until we find an EOF
+        execUntil(OpCode.EOF);
       }
 
       return returnValue;
@@ -201,12 +195,6 @@ public final class Interpreter {
       case NOP:
         nop();
         break;
-      case BEG:
-        begin();
-        break;
-      case END:
-        end();
-        break;
       case PUSH:
         push();
         break;
@@ -266,17 +254,6 @@ public final class Interpreter {
 
     void nop() {
       // And a good nop to you, dear sir.
-    }
-
-
-    void begin() {
-      // Ignored. BEGIN is effectively a no-op the way we process.
-    }
-
-
-    void end() {
-      // Anytime we receive an END, we're going to clear our stack.
-      stack.clear();
     }
 
 

--- a/src/main/java/pokerga/OpCode.java
+++ b/src/main/java/pokerga/OpCode.java
@@ -2,7 +2,7 @@ package pokerga;
 
 public enum OpCode {
 
-  NOP, BEG, END,
+  NOP,
   PUSH,
   DROP, DUP, NEG,
   ADD, SUB, INCR, DECR,
@@ -16,8 +16,7 @@ public enum OpCode {
 
   // This array is deliberately constructed to match the layout of the opcode
   // byte codes directly. The two dimensional array mirrors the two-digit hexcode
-  // encoding used by the opcode table. The first row, index '0' stores the first
-  // three values of the opcode table: NOP(0x00), BEGIN(0x01), END(0x02)
+  // encoding used by the opcode table.
   //
   // A lookup can be performed against this array in order to find the correct
   // opcode, by effectively taking the index from the two characters of the hex
@@ -27,7 +26,7 @@ public enum OpCode {
   // opcode value takes any value in the second nibble of the byte. e.g. it takes
   // a parameter value in the opcode. PUSH, READ, CNT all do this.
   private static OpCode[][] opcodes = {
-      {NOP, BEG, END},
+      { NOP },
       {PUSH},
       {DROP, DUP, NEG},
       {ADD, SUB, INCR, DECR},

--- a/src/test/java/pokerga/InterpreterInstTest.java
+++ b/src/test/java/pokerga/InterpreterInstTest.java
@@ -28,18 +28,6 @@ class InterpreterInstTest {
   }
 
   @Test
-  void testBeginEndBoundary() {
-    // This will test that we don't PUSH any items outside of a BEG/END boundary.
-    // We have two pushes here, but our stack will be cleared with the call to END.
-    // So we're only going to see the last one (1D) in this test.
-    String subj = "1A 01 1B 02 1C 01 1D";
-    Inst inst = new Inst(null, subj, interpreter);
-    inst.process();
-
-    assertEquals((byte) 0xD, inst.stack.peek());
-  }
-
-  @Test
   void testUnderflow() {
     // Ensure that we don't throw any exceptions for these weird parse states.
     String[] subs = { "", " ", "  ", "x", "00", "01", "02", "01 02 02", "01 ", "01  " };
@@ -53,20 +41,6 @@ class InterpreterInstTest {
         fail("Buffer Underflow detected for subject: ->" + sub + "<-", e);
       }
     }
-  }
-
-  @Test
-  void testNestedBegin() {
-    String subj = "01 01 02";
-    Inst inst = new Inst(null, subj, interpreter);
-    inst.process();
-  }
-
-  @Test
-  void testNestedEnd() {
-    String subj = "01 02 02";
-    Inst inst = new Inst(null, subj, interpreter);
-    inst.process();
   }
 
   @Test
@@ -119,8 +93,8 @@ class InterpreterInstTest {
   @Test
   void testIf() {
     // Test when the stack is 'true'
-    // BEGIN, PUSH(1), IF, PUSH(A), ENDIF
-    String subj = "01 11 40 1A 41";
+    // NOP, PUSH(1), IF, PUSH(A), ENDIF
+    String subj = "00 11 40 1A 41";
     Inst inst = new Inst(null, subj, interpreter);
     ByteStack stack = inst.stack;
 
@@ -129,8 +103,8 @@ class InterpreterInstTest {
     assertEquals(0xA, stack.pop());
 
     // Test when the stack is 'false'
-    // BEGIN, PUSH(0), IF, PUSH(A), ENDIF
-    subj = "01 10 40 1A 41";
+    // PUSH(0), IF, PUSH(A), ENDIF
+    subj = "00 10 40 1A 41";
     inst = new Inst(null, subj, interpreter);
     stack = inst.stack;
 


### PR DESCRIPTION
The BEGIN / END opcodes were an idea to have more fit organisms being able to convey their instructions in little segments and potentially passing these down. But in practice they likely did more harm than good, especially for early organisms.